### PR TITLE
Expand XNAT user documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a Sphinx-based documentation project for NYUAD XNAT User Documentation.
 
 ### Prerequisites
 
-- **Python 3.8 or higher** (required for Sphinx 7.2.6)
+- **Python 3.10 or higher** (matching the ReadTheDocs build configuration)
 - pip (Python package manager)
 
 **Note:** If you're on macOS and don't have Python 3.8+, you can install it using:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==9.1.0
-sphinx-rtd-theme==3.1.0
-myst-parser==5.1.0
-sphinx-autobuild==2025.8.25
+sphinx==7.2.6
+sphinx-rtd-theme==2.0.0
+myst-parser==2.0.0
+sphinx-autobuild==2024.10.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
-sphinx-rtd-theme
-myst-parser
-sphinx-autobuild
+sphinx==9.1.0
+sphinx-rtd-theme==3.1.0
+myst-parser==5.1.0
+sphinx-autobuild==2025.8.25

--- a/docs/source/data_download/desktop_client.rst
+++ b/docs/source/data_download/desktop_client.rst
@@ -73,7 +73,7 @@ Getting Help
 **For Desktop Client specific issues:**
 
 - Review the `official XNAT Desktop Client documentation <https://wiki.xnat.org/xnat-tools/xnat-desktop-client-dxm>`_
-- Check `application settings guide <https://wiki.xnat.org/xnat-tools/xnat-desktop-client-dxm/application-settings>`_
+- Check `application settings guide <https://wiki.xnat.org/xnat-tools/application-settings>`_
 - Consult `version compatibility matrix <https://wiki.xnat.org/xnat-tools/desktop-client-version-compatibility-matrix>`_
 
 Next Steps

--- a/docs/source/data_download/python_scripts.rst
+++ b/docs/source/data_download/python_scripts.rst
@@ -1,151 +1,595 @@
-Download via Python
-===================
+XNAT API with Python
+====================
 
-Automated data download using Python scripts from the XNAT template-scripts repository.
+This guide shows how to use Python to work with NYUAD XNAT directly from your laptop, lab workstation, or Jubail HPC. It is intended for users who want to create their own scripts instead of asking XNAT administrators to write one-off download or processing helpers.
 
-Overview
---------
+Most users should start with the official Python package:
 
-Python scripts provide automated, programmatic data access with batch download capabilities and integration with analysis workflows.
+- Install package: ``pip install xnat``
+- Package documentation: `XNAT Python Client <https://xnat.readthedocs.io/en/stable/>`_
+- XNAT server: ``https://xnat.abudhabi.nyu.edu``
 
-Available Scripts
+When to Use the API
+-------------------
+
+Use the API when the browser or Desktop Client is too manual for your workflow. Common examples include:
+
+- Download all scans for selected subjects and sessions.
+- Download only one scan type, such as T1w, DWI, or fieldmaps.
+- Download only pipeline outputs, such as ``fmriprep``, ``mriqc``, ``rawdata``, or ``freesurfer`` resources.
+- Extract one specific file from many sessions, such as FreeSurfer ``aseg.stats``.
+- Build a manifest of what exists in XNAT before downloading.
+- Download data directly to Jubail before running your own processing.
+- Run the same script repeatedly without re-downloading files that already exist.
+
+Prefer the XNAT Desktop Client for simple large DICOM downloads. Prefer the API when you need filtering, manifests, automation, or downstream analysis.
+
+Safety Rules
+------------
+
+Before writing scripts, follow these rules:
+
+- Start with read-only tasks: list projects, list sessions, list resources, then download.
+- Do not delete, overwrite, archive, or upload data from a script unless you have discussed the plan with the XNAT administrators.
+- Test on one subject and one session before running a whole project.
+- Keep a manifest of what your script downloaded.
+- Never put token secrets directly in scripts, notebooks, GitHub repos, email, Slack, or shared folders.
+- If an AI tool helps you write code, ask it to avoid destructive operations and to keep credentials in environment variables.
+
+Create an Alias Token
+---------------------
+
+Use an XNAT alias token rather than your Google password.
+
+1. Log into XNAT.
+2. Click your user name in the top right.
+3. Open **Manage Alias Tokens**.
+4. Create a new token.
+5. Copy the token alias and token secret.
+
+Treat the alias and secret like a password. If you think they were exposed, delete the token and create a new one.
+
+Environment Setup
 -----------------
 
-Four main Python scripts are available for different download tasks:
+Laptop or Workstation
+~~~~~~~~~~~~~~~~~~~~~
 
-**1. List Projects** (``1_list_projects.py``)
-   Lists all accessible projects on XNAT with IDs, names, and descriptions.
+Create a small Python environment:
 
-**2. List Subjects** (``2_list_subjects.py``)
-   Shows detailed information for subjects in a project, including sessions, scans, and metadata.
+.. code-block:: bash
 
-**3. Download Single Scan** (``3_download_single_scan.py``)
-   Downloads DICOM files from a specific scan with precise control over selection.
+   python3 -m venv xnat-api-env
+   source xnat-api-env/bin/activate
+   python -m pip install --upgrade pip
+   python -m pip install xnat pandas python-dotenv
 
-**4. Download Session** (``4_download_session.py``)
-   Downloads all scans from a session, with optional filtering by scan type.
+If you prefer conda:
 
-Setup Instructions
+.. code-block:: bash
+
+   conda create -n xnat-api python=3.11
+   conda activate xnat-api
+   pip install xnat pandas python-dotenv
+
+Jubail HPC
+~~~~~~~~~~
+
+For workflows that produce large outputs, it is often better to download directly to Jubail instead of downloading to a laptop and uploading again.
+
+.. code-block:: bash
+
+   ssh <your-netid>@jubail.abudhabi.nyu.edu
+   mkdir -p ~/xnat-api-work
+   cd ~/xnat-api-work
+   python3 -m venv xnat-api-env
+   source xnat-api-env/bin/activate
+   python -m pip install --upgrade pip
+   python -m pip install xnat pandas python-dotenv
+
+For long downloads or downstream processing, use a Jubail job instead of leaving work running in an interactive shell. See the CRC documentation for `Jubail system details <https://crc-docs.abudhabi.nyu.edu/hpc/system/index.html>`_ and `SLURM job submission <https://crc-docs.abudhabi.nyu.edu/hpc/jobs/quick_start.html>`_.
+
+Secrets Management
 ------------------
 
-**1. Environment Setup**
+Option 1: Environment Variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is the recommended default.
 
 .. code-block:: bash
 
-   # Create conda environment
-   conda create -n xnat-env python=3.9
-   conda activate xnat-env
-   pip install xnat
+   export XNAT_HOST="https://xnat.abudhabi.nyu.edu"
+   export XNAT_USER="your-token-alias"
+   export XNAT_PASS="your-token-secret"
 
-**2. Get Template Scripts**
+Then your Python code can read:
 
-.. code-block:: bash
+.. code-block:: python
 
-   git clone https://github.com/XNAT-NYUAD/template-scripts.git
-   cd template-scripts
+   import os
 
-**3. Configure Authentication**
+   XNAT_HOST = os.environ["XNAT_HOST"]
+   XNAT_USER = os.environ["XNAT_USER"]
+   XNAT_PASS = os.environ["XNAT_PASS"]
 
-1. Create API token in XNAT:
-   - Go to your profile → "Manage Alias Tokens"
-   - Click "Create New Token"
-   - Copy the alias and secret values
+Option 2: Private ``.env`` File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-2. Edit each script file and replace:
-   - ``TOKEN_USER = "<paste your token alias here>"``
-   - ``TOKEN_SECRET = "<paste your token secret here>"``
-
-Usage Examples
---------------
-
-**List Available Projects**
+For a project folder on your own machine:
 
 .. code-block:: bash
 
-   python 1_list_projects.py
+   cat > .env <<'EOF'
+   XNAT_HOST=https://xnat.abudhabi.nyu.edu
+   XNAT_USER=your-token-alias
+   XNAT_PASS=your-token-secret
+   EOF
+   chmod 600 .env
+   echo ".env" >> .gitignore
 
-**Examine Subject Details**
+Use it in Python:
+
+.. code-block:: python
+
+   from dotenv import load_dotenv
+   import os
+
+   load_dotenv()
+   XNAT_HOST = os.environ["XNAT_HOST"]
+   XNAT_USER = os.environ["XNAT_USER"]
+   XNAT_PASS = os.environ["XNAT_PASS"]
+
+On Jubail, keep token files in your home directory or a private project directory. Do not store secrets in shared group folders unless the permissions are restricted.
+
+Option 3: Prompt at Runtime
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Prompting avoids saving secrets on disk:
+
+.. code-block:: python
+
+   import getpass
+
+   XNAT_USER = input("XNAT alias token: ")
+   XNAT_PASS = getpass.getpass("XNAT alias secret: ")
+
+First Connection Test
+---------------------
+
+Create ``01_test_connection.py``:
+
+.. code-block:: python
+
+   import os
+   import xnat
+
+   host = os.environ.get("XNAT_HOST", "https://xnat.abudhabi.nyu.edu")
+   user = os.environ["XNAT_USER"]
+   password = os.environ["XNAT_PASS"]
+
+   with xnat.connect(host, user=user, password=password) as session:
+       print("Connected to:", host)
+       print("Accessible projects:")
+       for project_id in sorted(session.projects.keys()):
+           print(" -", project_id)
+
+Run it:
 
 .. code-block:: bash
 
-   # Show first subject in project
-   python 2_list_subjects.py
-   
-   # Show specific subject
-   python 2_list_subjects.py --subject sub-001
+   python 01_test_connection.py
 
-**Download Single Scan**
+If this fails, check VPN/network access, token spelling, and project permissions.
 
-.. code-block:: bash
+Common XNAT Objects
+-------------------
 
-   # Download first scan (uses default project)
-   python 3_download_single_scan.py
-   
-   # Download specific scan
-   python 3_download_single_scan.py --subject sub-001 --session ses-01 --scan 1
+The XNAT Python client exposes XNAT as a hierarchy:
 
-**Download Complete Session**
+::
 
-.. code-block:: bash
+   session
+     projects[project_id]
+       subjects[subject_label]
+         experiments[session_label]
+           scans[scan_id]
+             resources[resource_label]
+               files[file_name]
 
-   # Download all scans
-   python 4_download_session.py --subject sub-001 --session ses-01
-   
-   # Download only T1 and T2 scans
-   python 4_download_session.py --subject sub-001 --session ses-01 --scan-types T1 T2
+In XNAT, imaging sessions are often called ``experiments`` in the API. That is normal.
 
-Script Configuration
---------------------
+List Subjects, Sessions, Scans, and Resources
+---------------------------------------------
 
-Each script contains these configurable parameters:
+This is usually the first script to write for a new project.
 
-- ``XNAT_SERVER``: Server URL (default: https://xnat.abudhabi.nyu.edu)
-- ``TOKEN_USER``: Your API token alias
-- ``TOKEN_SECRET``: Your API token secret
-- ``PROJECT_ID``: Default project (default: rokerslab_ari-clean)
+.. code-block:: python
 
-Output Structure
-----------------
+   import os
+   import xnat
 
-Downloaded files are organized as:
+   PROJECT_ID = "your_project_id"
+
+   with xnat.connect(
+       os.environ.get("XNAT_HOST", "https://xnat.abudhabi.nyu.edu"),
+       user=os.environ["XNAT_USER"],
+       password=os.environ["XNAT_PASS"],
+   ) as session:
+       project = session.projects[PROJECT_ID]
+
+       for subject in project.subjects.values():
+           print(f"Subject: {subject.label}")
+           for experiment in subject.experiments.values():
+               print(f"  Session: {experiment.label}")
+               for scan in experiment.scans.values():
+                   resource_names = ", ".join(scan.resources.keys())
+                   print(f"    Scan {scan.id}: {scan.type} resources=[{resource_names}]")
+               if experiment.resources:
+                   print("    Session resources:", ", ".join(experiment.resources.keys()))
+
+Use the output from this script to decide what to download.
+
+Download Selected DICOM Scans
+-----------------------------
+
+This pattern appears often in project-specific scripts: choose subjects, choose sessions, then download each scan resource.
+
+.. code-block:: python
+
+   import os
+   from pathlib import Path
+   import xnat
+
+   PROJECT_ID = "your_project_id"
+   SUBJECTS = ["Subject_0001", "Subject_0002"]
+   SESSIONS = ["ses_01"]
+   OUTPUT_DIR = Path("xnat_downloads")
+
+   def safe_name(value):
+       return "".join(c if c.isalnum() or c in "-_." else "_" for c in str(value))
+
+   with xnat.connect(
+       os.environ.get("XNAT_HOST", "https://xnat.abudhabi.nyu.edu"),
+       user=os.environ["XNAT_USER"],
+       password=os.environ["XNAT_PASS"],
+   ) as session:
+       project = session.projects[PROJECT_ID]
+
+       for subject_label in SUBJECTS:
+           subject = project.subjects.get(subject_label)
+           if subject is None:
+               print("Missing subject:", subject_label)
+               continue
+
+           for experiment in subject.experiments.values():
+               if SESSIONS and experiment.label not in SESSIONS:
+                   continue
+
+               for scan in experiment.scans.values():
+                   if "DICOM" not in scan.resources:
+                       continue
+
+                   scan_dir = (
+                       OUTPUT_DIR
+                       / safe_name(subject.label)
+                       / safe_name(experiment.label)
+                       / f"scan-{safe_name(scan.id)}_{safe_name(scan.type)}"
+                   )
+                   if scan_dir.exists() and any(scan_dir.iterdir()):
+                       print("Skipping existing:", scan_dir)
+                       continue
+
+                   print("Downloading:", subject.label, experiment.label, scan.id, scan.type)
+                   scan.resources["DICOM"].download_dir(str(scan_dir))
+
+This downloads one directory per scan. For large projects, add logging and retry logic.
+
+Download Session Resources
+--------------------------
+
+Pipeline outputs usually live in session resources such as ``rawdata``, ``mriqc``, ``fmriprep``, ``freesurfer``, or ``tractoflow``.
+
+.. code-block:: python
+
+   import os
+   from pathlib import Path
+   import xnat
+
+   PROJECT_ID = "your_project_id"
+   RESOURCE_LABEL = "fmriprep"
+   OUTPUT_DIR = Path("pipeline_outputs")
+
+   with xnat.connect(
+       os.environ.get("XNAT_HOST", "https://xnat.abudhabi.nyu.edu"),
+       user=os.environ["XNAT_USER"],
+       password=os.environ["XNAT_PASS"],
+   ) as session:
+       project = session.projects[PROJECT_ID]
+
+       for subject in project.subjects.values():
+           for experiment in subject.experiments.values():
+               resource = experiment.resources.get(RESOURCE_LABEL)
+               if resource is None:
+                   continue
+
+               out_dir = OUTPUT_DIR / subject.label / experiment.label / RESOURCE_LABEL
+               print("Downloading resource:", subject.label, experiment.label, RESOURCE_LABEL)
+               resource.download_dir(str(out_dir))
+
+For fMRIPrep and TractoFlow, resources can be large. Test with one subject before downloading a full project.
+
+Download One Specific File From Many Sessions
+---------------------------------------------
+
+A common request is: "Download every FreeSurfer ``aseg.stats`` file, but not the full fMRIPrep output." The safest approach is:
+
+1. Loop through subjects and sessions.
+2. Inspect the resource file listing.
+3. Download only files whose path ends with ``stats/aseg.stats``.
+4. Save a manifest.
+
+The exact file listing can vary by resource, so inspect the file names before downloading. Many FreeSurfer resources store this file as ``<subject>/stats/aseg.stats``.
+
+.. code-block:: python
+
+   import csv
+   import os
+   from pathlib import Path
+   import xnat
+
+   PROJECT_ID = "your_project_id"
+   RESOURCE_LABEL = "freesurfer"
+   OUTPUT_DIR = Path("aseg_stats_bids")
+   MANIFEST = OUTPUT_DIR / "aseg_stats_manifest.tsv"
+
+   def safe_label(value):
+       return "".join(c if c.isalnum() or c in "-_" else "_" for c in str(value))
+
+   with xnat.connect(
+       os.environ.get("XNAT_HOST", "https://xnat.abudhabi.nyu.edu"),
+       user=os.environ["XNAT_USER"],
+       password=os.environ["XNAT_PASS"],
+   ) as session:
+       project = session.projects[PROJECT_ID]
+       MANIFEST.parent.mkdir(parents=True, exist_ok=True)
+
+       with MANIFEST.open("w", newline="", encoding="utf-8") as manifest_file:
+           writer = csv.writer(manifest_file, delimiter="\t")
+           writer.writerow(["subject", "session", "resource", "xnat_file", "local_path"])
+
+           for subject in project.subjects.values():
+               for experiment in subject.experiments.values():
+                   if RESOURCE_LABEL not in experiment.resources:
+                       continue
+
+                   resource = experiment.resources[RESOURCE_LABEL]
+                   for file_key, file_obj in resource.files.items():
+                       file_name = str(file_key or file_obj.name).replace("\\\\", "/")
+                       if not file_name.endswith("stats/aseg.stats"):
+                           continue
+
+                       local_path = (
+                           OUTPUT_DIR
+                           / "derivatives"
+                           / "freesurfer"
+                           / safe_label(subject.label)
+                           / safe_label(experiment.label)
+                           / "stats"
+                           / "aseg.stats"
+                       )
+                       local_path.parent.mkdir(parents=True, exist_ok=True)
+
+                       if local_path.exists():
+                           print("Skipping existing:", local_path)
+                       else:
+                           print("Downloading:", file_name, "->", local_path)
+                           file_obj.download(str(local_path))
+
+                       writer.writerow([subject.label, experiment.label, RESOURCE_LABEL, file_name, local_path])
+
+The local output is intentionally BIDS-like:
 
 .. code-block:: text
 
-   downloaded_data/
-   ├── scan-1_T1/          # Single scan downloads
-   │   ├── file1.dcm
-   │   └── file2.dcm
-   └── session-ses-01/     # Session downloads
-       ├── scan-1_T1/
-       ├── scan-2_T2/
-       └── scan-3_func/
+   aseg_stats_bids/
+     derivatives/
+       freesurfer/
+         Subject_0001/
+           ses_01/
+             stats/
+               aseg.stats
+     aseg_stats_manifest.tsv
 
-Security Best Practices
------------------------
+Parse ``aseg.stats`` Into a CSV
+-------------------------------
 
-- Never commit API tokens to version control
-- Regularly rotate API tokens
-- Use project-specific tokens when possible
-- Store tokens in environment variables for production use
+After downloading ``aseg.stats`` files, you can parse them into a table. This minimal parser extracts ``Volume_mm3`` values by structure name.
+
+.. code-block:: python
+
+   import csv
+   from pathlib import Path
+
+   INPUT_DIR = Path("aseg_stats_bids")
+   OUTPUT_CSV = Path("aseg_stats_wide.csv")
+
+   def parse_aseg(path):
+       measures = {}
+       columns = None
+       with path.open("r", encoding="utf-8", errors="replace") as f:
+           for line in f:
+               line = line.strip()
+               if line.startswith("# ColHeaders"):
+                   columns = line.split()[2:]
+                   continue
+               if not line or line.startswith("#") or columns is None:
+                   continue
+               values = line.split()
+               row = dict(zip(columns, values))
+               name = row.get("StructName")
+               volume = row.get("Volume_mm3")
+               if name and volume:
+                   measures[name] = volume
+       return measures
+
+   rows = []
+   all_columns = set()
+
+   for stats_path in INPUT_DIR.rglob("aseg.stats"):
+       parts = stats_path.parts
+       subject = next((p for p in parts if p.startswith("sub-") or p.startswith("Subject_")), "")
+       session = next((p for p in parts if p.startswith("ses")), "")
+       values = parse_aseg(stats_path)
+       values.update({"subject": subject, "session": session, "path": str(stats_path)})
+       rows.append(values)
+       all_columns.update(values)
+
+   columns = ["subject", "session", "path"] + sorted(c for c in all_columns if c not in {"subject", "session", "path"})
+   with OUTPUT_CSV.open("w", newline="", encoding="utf-8") as f:
+       writer = csv.DictWriter(f, fieldnames=columns)
+       writer.writeheader()
+       writer.writerows(rows)
+
+   print("Wrote:", OUTPUT_CSV)
+
+For production analysis, keep the original ``aseg.stats`` files and the manifest alongside the CSV.
+
+Download Directly to Jubail and Run Your Own Processing
+-------------------------------------------------------
+
+For larger workflows, use this pattern:
+
+1. Create a script locally and test it on one session.
+2. Copy the script to Jubail, or write it directly in your Jubail project folder.
+3. Store XNAT credentials in environment variables or a private ``.env`` file.
+4. Download data to a project scratch/work directory.
+5. Submit downstream processing as a SLURM job.
+
+Example job wrapper:
+
+.. code-block:: bash
+
+   #!/bin/bash
+   #SBATCH --job-name=xnat-download-test
+   #SBATCH --time=01:00:00
+   #SBATCH --cpus-per-task=2
+   #SBATCH --mem=8G
+   #SBATCH --output=xnat-download-%j.out
+   #SBATCH --error=xnat-download-%j.err
+
+   set -euo pipefail
+
+   cd "$HOME/xnat-api-work"
+   source xnat-api-env/bin/activate
+
+   # Keep this file private: chmod 600 ~/.xnat.env
+   source "$HOME/.xnat.env"
+
+   python 01_test_connection.py
+   python download_selected_resources.py
+
+Submit it:
+
+.. code-block:: bash
+
+   sbatch xnat_download_job.sh
+
+Do not print token secrets in job logs. If a script prints its configuration, redact ``XNAT_PASS`` before sharing logs.
+
+Build Scripts With AI Assistance
+--------------------------------
+
+AI tools can be helpful for turning a clear download request into a script. They are most useful when you give them:
+
+- The XNAT server URL.
+- The project ID.
+- The exact subject/session labels you want.
+- The resource label, such as ``DICOM``, ``rawdata``, ``fmriprep``, ``mriqc``, ``freesurfer``, or ``tractoflow``.
+- The file pattern, such as ``stats/aseg.stats`` or ``*.html``.
+- The desired output structure.
+
+Use a prompt like this:
+
+.. code-block:: text
+
+   Write a Python script using the xnat package to connect to XNAT with
+   XNAT_HOST, XNAT_USER, and XNAT_PASS from environment variables.
+   The script should be read-only. It should not delete, upload, archive,
+   overwrite, or modify anything on XNAT.
+
+   Task:
+   - Project: <project_id>
+   - Subjects: <list or "all">
+   - Sessions: <list or "all">
+   - Resource: <resource label>
+   - File pattern: <for example, stats/aseg.stats>
+   - Output directory: <local path>
+
+   Requirements:
+   - Do a dry run option first.
+   - Skip files that already exist.
+   - Write a manifest TSV.
+   - Print clear progress messages.
+   - Keep token secrets out of the code and logs.
+
+Always review AI-generated scripts before running them. If you are unsure whether a script is safe, send it to admin.nyuad.xnat@nyu.edu and ask for review.
+
+Recommended Script Features
+---------------------------
+
+For scripts you plan to reuse, add:
+
+- ``--dry-run`` to list planned downloads without writing files.
+- ``--project`` to make the project configurable.
+- ``--subject`` and ``--session`` filters.
+- ``--resource`` to choose a resource label.
+- ``--output-dir`` to choose where files go.
+- Existing-file checks to avoid re-downloading.
+- A manifest TSV with subject, session, resource, XNAT file name or URI, and local path.
+- Logging to a text file.
+- A small test mode that stops after the first matching session.
 
 Troubleshooting
 ---------------
 
-**Authentication Errors**
-   Verify your API token is correct and hasn't expired. Create a new token if needed.
+**Authentication fails**
+   Confirm that ``XNAT_USER`` is the alias token and ``XNAT_PASS`` is the alias secret. Do not use your Google password.
 
-**Project Not Found**
-   Check project ID spelling and ensure you have access permissions.
+**Cannot reach XNAT**
+   Confirm you are on the NYUAD network or VPN. On Jubail, confirm that the job environment has network access to XNAT.
 
-**No Scans Found**
-   Verify subject/session IDs exist and contain DICOM data.
+**Project or subject is missing**
+   Check spelling and project access. The API only shows data your account is allowed to see.
 
-**Download Failures**
-   Check network connectivity and ensure sufficient disk space.
+**Resource label is missing**
+   Open the session in XNAT and check the resource name. Common labels include ``DICOM``, ``rawdata``, ``mriqc``, ``fmriprep``, ``freesurfer``, and ``tractoflow``, but projects can differ.
 
-Next Steps
-----------
+**Downloads are incomplete**
+   Add retry logic, skip existing complete files, and keep a manifest. For large DICOM downloads, consider using the Desktop Client.
 
-- Learn about :doc:`../understanding_data/bids` for data organization
-- See :doc:`../processing_pipelines/overview` for processing pipelines
-- Try :doc:`matlab_scripts` for MATLAB-based downloads
+**The script works for one subject but fails for a project**
+   Add error handling around each subject/session so one bad session does not stop the whole run.
+
+Getting Help
+------------
+
+If you need help, email admin.nyuad.xnat@nyu.edu with:
+
+- The project ID.
+- The subject/session you tested.
+- The resource or file you are trying to download.
+- The script or AI prompt you used.
+- The error message or log.
+
+Related Documentation
+---------------------
+
+- :doc:`browser` - Browser download method
+- :doc:`desktop_client` - Desktop Client download method
+- :doc:`../working_with_xnat/access` - Alias token creation
+- :doc:`../processing_pipelines/fmriprep` - fMRIPrep outputs
+- :doc:`../processing_pipelines/mriqc` - MRIQC outputs
+- :doc:`../processing_pipelines/tractoflow` - TractoFlow outputs
+- `XNAT Python Client documentation <https://xnat.readthedocs.io/en/stable/>`_
+- `CRC Jubail documentation <https://crc-docs.abudhabi.nyu.edu/>`_

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -1,13 +1,12 @@
 Getting Started with XNAT Documentation
 =======================================
 
-Welcome to the NYUAD XNAT User Documentation. This guide is designed to help you effectively use xnat with a focus on practical, hands-on workflows.
-This documentation is currently in development and is not yet complete.
+Welcome to the NYUAD XNAT User Documentation. This guide is designed to help you use XNAT through practical, hands-on workflows.
 
 Documentation Structure
 -----------------------
 
-This documentation focuses on **three core activities** :
+This documentation focuses on the core activities most users need:
 
 .. image:: ../_static/1.1.docStructure.png 
    :alt: XNAT Documentation Structure
@@ -24,7 +23,7 @@ This documentation focuses on **three core activities** :
    Multiple approaches: browser, desktop client, and automated scripts
 
 **Additional Resources:**
-This documentation also includes step‑by‑step guidance on account setup and platform navigation, best‑practice instructions for data uploads and project management, and a consolidated troubleshooting & FAQ section. Advanced users can also consult our dedicated guide on building and deploying custom pipelines within XNAT.
+This documentation also includes account setup, data upload, prearchive review, project management, and support guidance.
 
 
 How to Use This Documentation
@@ -35,11 +34,11 @@ How to Use This Documentation
 1. Read :doc:`what_is_xnat` to understand what XNAT is and how we use it at NYUAD
 2. Start with :doc:`../working_with_xnat/access` to set up your account
 3. Read :doc:`../understanding_data/overview` to understand data formats  
-4. Browse :doc:`../processing_pipelines/overview` to see available tools
-5. For general XNAT concepts, see the `official XNAT getting started guide <https://wiki.xnat.org/documentation/getting-started-with-xnat>`_
+4. Review :doc:`../working_with_xnat/uploading` before adding new data
+5. Browse :doc:`../processing_pipelines/overview` to see available tools
 
 **If you're experienced:**
 
 - Jump directly to the pipeline documentation for specific tools
 - Use the download methods section for efficient data retrieval
-
+- Use :doc:`../support/troubleshooting` when a workflow fails or produces unexpected output

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 NYUAD XNAT User Documentation
 ==============================
 
-Welcome to the NYUAD XNAT User Documentation. This guide is designed to help you effectively use xnat with a focus on practical, hands-on workflows.
+Welcome to the NYUAD XNAT User Documentation. This guide is designed to help you effectively use XNAT with a focus on practical, hands-on workflows.
 
    
 .. toctree::
@@ -21,6 +21,8 @@ Welcome to the NYUAD XNAT User Documentation. This guide is designed to help you
    working_with_xnat/transferring_data
    working_with_xnat/uid_errors_archiving
    working_with_xnat/install_desktop_client
+   working_with_xnat/navigation
+   working_with_xnat/project_management
    working_with_xnat/enabling_pipelines
    working_with_xnat/running_pipelines
    working_with_xnat/parallel_processing
@@ -64,10 +66,3 @@ Welcome to the NYUAD XNAT User Documentation. This guide is designed to help you
    support/data_loss_recovery
    support/contributing
    support/contact
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Coming Soon
-
-   working_with_xnat/navigation
-   working_with_xnat/project_management

--- a/docs/source/processing_pipelines/ari-validator.rst
+++ b/docs/source/processing_pipelines/ari-validator.rst
@@ -90,7 +90,7 @@ Output and Reports
      </div>
    </div>
 
-*can you tell what is wrong with the data on the right?*
+Compare the examples to see how validation issues appear in the log output.
 
 
 
@@ -323,14 +323,14 @@ Data Validation Dashboard
 Troubleshooting
 ---------------
 
-- **SBREF:** Sometimes the phase encoding directions is flipped even though the the AP/PA direction in the file name is correct. You should delete the incorrect sbref files. `See example of incorrect SBREF <../_static/3.5.sbref-flip-example.png>`_ 
-- **IntendedFor:** Check the intendedFor field in the epi.json file in fmap and see exacly what is incorrect. First thing to check is if there's missing or extra files. If that's not the issue, then please contact us and we can help you take a look.
+- **SBREF:** Sometimes the phase encoding direction is flipped even though the AP/PA direction in the file name is correct. Review the affected files and coordinate with the project owner or XNAT administrators before removing anything. `See example of incorrect SBREF <../_static/3.5.sbref-flip-example.png>`_
+- **IntendedFor:** Check the ``IntendedFor`` field in the ``epi.json`` file in ``fmap`` and identify what is incorrect. First check for missing or extra files. If that is not the issue, contact us and we can help you take a look.
 - **DWI Parameters:** Version 1 of the DWI protocol is deprecated due to mismatches in the DWI and reverse b0 parameters. If someone was not scanned under version 1 yet still has mismatching issues then you need to investigate further. 
 - **Incorrect dimensions and TR:** Check if data is incomplete or if wrong sequence was used.
-- **Missing files:** transfer missing files to the correct location.
-- **Extra files:** delete extra files depending on the reason.
-- **Multiple sessions:** Scans collected in separate sessions should be merged into one session. For example, if anantomicals were skipped because they had already been collected before, please transfer a copy of the anat files to the new session so the data is complete.
-- **Repeated scans:** If a scan was collected multiple times, please delete the extra scans according to why the scan was repeated. Ideally, invalid scans should not be sent from scanner to XNAT in the first place.
+- **Missing files:** Re-upload or transfer missing files to the correct location after confirming the intended session structure.
+- **Extra files:** Review extra files and remove only files that the project owner confirms are invalid or out of scope.
+- **Multiple sessions:** Scans collected in separate sessions may need to be consolidated for analysis. For example, if anatomical scans were skipped because they had already been collected before, coordinate with the project owner or administrators to copy the required anatomical files into the analysis session.
+- **Repeated scans:** If a scan was collected multiple times, decide which scan should be retained based on the acquisition notes and project quality-control criteria.
 
 .. raw:: html
 
@@ -353,35 +353,27 @@ We do **not** check everything. Do not assume that data passing our check is per
 
    <br>
 
-ARI Project Versions
---------------------
+Choosing the Correct ARI Project
+--------------------------------
 
-Over time, several ARI project folders have been created. This log clarifies the purpose and status of each:
+Over time, several ARI project folders have been created for active data collection, historical data, validation, and migration work. Most users should work only in the project folder assigned by the ARI project team.
 
-**1. ARI (ari)** - Current / Active
+**Current ARI data**
 
-- This is the main project folder displayed on the dashboard above. All new data collected after Summer 2025 is stored here.
-- Data here is supposed to be verified and valid. If invalid scans are found, they are removed.
-- This is the primary folder for end-users.
+- The current ARI project is the primary folder for end users.
+- New data should be validated before downstream preprocessing.
+- If a subject appears in more than one ARI-related project, confirm which project should be used before downloading or processing data.
 
-**2. ARI HFS - new (rokerslab_ari-hfs_2024_001)** - Archive / In-Progress
+**Historical or migration projects**
 
-- Contains all older data collected, includes both valid and invalid data.
-- RAs are actively validating this folder. Valid data is being migrated to the new **ARI** folder, while invalid data is either removed or kept here as an archive.
+- Some older folders may contain historical, migrated, or partially validated data.
+- Do not assume historical folders are ready for analysis.
+- Contact the project team or XNAT administrators if you are unsure which folder to use.
 
-**3. ARI Clean (Rokerslab_ari-clean)** - Internal / Testing
+**External collaborations**
 
-- Made for temporary analysis of the 100 ARI dataset. XNAT admins also use this as a testing ground for pipelines.
-- Users do not need access to this folder.
-
-**4. ARI HFS (Rokerslab_vri-hfs_2024_001)** - Deprecated
-
-- The first ARI folder on XNAT. It had many issues and is now outdated.
-- Users no longer need to access this folder.
-
-**5. UAEU ARI (uaeu_ari)** - Active / External
-
-- Project hosting the ARI data collected at UAEU.
+- Collaborating sites may have separate ARI project folders.
+- Confirm access and data-use expectations with the project team before using external-site data.
 
 .. raw:: html
 

--- a/docs/source/processing_pipelines/fmriprep.rst
+++ b/docs/source/processing_pipelines/fmriprep.rst
@@ -47,7 +47,9 @@ Navigate to your **session** on XNAT, click **"Run Preprocessing Pipeline"**, se
 - **FMRIPrep Flags**: Text box for additional command-line options such as ``--output-spaces MNI152NLin2009cAsym:res-2``. For more information on the flags, see the `fMRIPrep documentation <https://fmriprep.org/en/stable/usage.html#command-line-arguments>`_. Default output space is set to T1w, fsaverage, and fsnative : ``--output-space T1w:res-native fsnative:den-41k fsaverage:den-41k``. Read more about output spaces `here <https://fmriprep.org/en/25.1.3/spaces.html#standard-spaces>`_.
 
 .. note::
-   The actual submission script used for running fMRIPrep on the Jubail HPC is maintained at: `XNAT-NYUAD/fmriprep code/utilities/job.py <https://github.com/XNAT-NYUAD/fmriprep/blob/main/code/utilities/job.py>`_. This script handles job submission, resource allocation, and integration with XNAT sessions.
+   fMRIPrep runs on NYUAD-managed compute infrastructure after you submit it from XNAT. You do not need to log into the cluster or run fMRIPrep manually.
+
+   For users who need to understand the underlying compute environment, see the CRC documentation for `Jubail system details <https://crc-docs.abudhabi.nyu.edu/hpc/system/index.html>`_, `job submission and SLURM <https://crc-docs.abudhabi.nyu.edu/hpc/jobs/quick_start.html>`_, and the `detailed SLURM guide <https://crc-docs.abudhabi.nyu.edu/hpc/jobs/hpc_slurm.html>`_.
 
 
 Important Things to Pay Attention To
@@ -133,7 +135,7 @@ For detailed output descriptions, see the `fMRIPrep outputs documentation <https
 Troubleshooting
 ---------------
 
-*Email us your error logs and we will add it to the troubleshooting section* 
+If fMRIPrep fails, check the output resource for logs and include them when contacting support. Common issues include invalid BIDS inputs, missing anatomical images, fieldmap problems, and FreeSurfer failures caused by poor T1w image quality.
 
 Next Steps After Preprocessing
 ------------------------------
@@ -143,6 +145,4 @@ Next Steps After Preprocessing
 
 .. note::
    Currently, we are running **fMRIPrep** (v24.1.1) and **FreeSurfer** (v7.3.2). We are working on making more versions available. If you have an urgent request for a specific version, please contact us.
-
-
 

--- a/docs/source/processing_pipelines/mriqc.rst
+++ b/docs/source/processing_pipelines/mriqc.rst
@@ -44,40 +44,14 @@ How to Launch the Pipeline
 
 Navigate to your **session** on XNAT, click **"Run Preprocessing Pipeline"**, select **"MRIQC"** from the pipeline dropdown, and then click **Review and Submit**.
 
-The current implementation on Jubail HPC is configured with standard settings:
+The current NYUAD XNAT implementation is configured with standard settings:
 
 - **Version**: MRIQC v24.0.2
-- **Resources**: 16 CPUs, 64 GB RAM (approx.), 4 hour time limit
 - **Modalities**: Automatically processes T1w, T2w, BOLD, and DWI images found in the BIDS directory.
 
-The underlying submission logic looks like the following:
+You do not need to configure compute resources manually. XNAT submits the job using the site-managed settings.
 
-.. code-block:: bash
-
-   #SBATCH -n 1            # number of tasks
-   #SBATCH -c 16           # number of cpus per task
-   #SBATCH -o slurm-{workflow_id}.out
-   #SBATCH -e slurm-{workflow_id}.err
-   #SBATCH --time=04:00:00
-
-   # Load singularity module
-   module load singularity
-   SINGULARITY_IMG=/scratch/mri/singularityimages/mriqc_24.0.2.sif
-
-   # Create output directory
-   mkdir -p "${OUTPUT_DIR}"
-
-   singularity run --cleanenv \
-       -B "${INPUT_DIR}":/data:ro \
-       -B "${OUTPUT_DIR}":/out \
-       -B "${WORKDIR}":/work \
-       "${SINGULARITY_IMG}" \
-       /data /out participant \
-       --participant-label {sub_label} \
-       -m T1w T2w bold dwi \
-       --work-dir /work \
-       --n_procs 16 \
-       -v
+For users who need more detail about the underlying compute environment, see the CRC documentation for `Jubail system details <https://crc-docs.abudhabi.nyu.edu/hpc/system/index.html>`_, `job submission and SLURM <https://crc-docs.abudhabi.nyu.edu/hpc/jobs/quick_start.html>`_, and the `detailed SLURM guide <https://crc-docs.abudhabi.nyu.edu/hpc/jobs/hpc_slurm.html>`_.
 
 .. raw:: html
 
@@ -198,7 +172,7 @@ Troubleshooting
 ---------------
 
 - **Job Timeout**: If the job fails with a timeout (exceeding 4 hours), it might be due to an unusually large dataset or high-resolution images. Please contact us for support.
-- **Missing Outputs**: If HTML reports are missing, check the ``logs`` directory (accessible via XNAT or the file system) to see if the pipeline crashed due to BIDS errors.
+- **Missing Outputs**: If HTML reports are missing, check the ``logs`` directory in the output resource to see whether the pipeline crashed due to BIDS errors.
 
 .. raw:: html
 

--- a/docs/source/processing_pipelines/tractoflow.rst
+++ b/docs/source/processing_pipelines/tractoflow.rst
@@ -71,55 +71,22 @@ TractoFlow generates a comprehensive set of derivatives. The XNAT pipeline trans
 **Key Output Files:**
 
 - ``DTI_Metrics/*_fa.nii.gz``: Use this for voxel-based analysis of white matter integrity.
-- ``Tractography/*.trk``: The whole-brain tractogram. This can be visualized in software like `MI-Brain <https://imeka.ca/mi-brain/>`_, `Dipy`, or `Mrtrix`.
+- ``Tractography/*.trk``: The whole-brain tractogram. This can be visualized in software like `MI-Brain <https://github.com/imeka/mi-brain>`_, Dipy, or MRtrix.
 - ``report.html``: A visual report of the processing steps. Check this to verify brain extraction and registration quality.
 
-Component Versions
-------------------
+Version and Runtime Notes
+-------------------------
 
-.. list-table::
-   :widths: 20 20 60
-   :header-rows: 1
+TractoFlow runs through NYUAD-managed compute infrastructure after you submit it from XNAT. You do not need to run Nextflow manually. If your analysis requires a specific TractoFlow or container version, contact support before launching a large batch.
 
-   * - Component
-     - Version
-     - Filename / Command
-   * - Java
-     - 1.8.0_31
-     - ``module load jdk/1.8.0_31``
-   * - Nextflow
-     - 21.10.6
-     - ``/scratch/mri/singularityimages/nextflow``
-   * - Tractoflow
-     - 2.4.4
-     - ``/scratch/mri/singularityimages/tractoflow/main.nf``
-   * - Container
-     - 1.6.0
-     - ``scilus_1.6.0.sif``
-
-Pipeline Command
-----------------
-
-The pipeline is executed on the cluster using the following command structure:
-
-.. code-block:: bash
-
-   /scratch/mri/singularityimages/nextflow run /scratch/mri/singularityimages/tractoflow/main.nf \
-       --input <input_directory> \
-       --output_dir <output_directory> \
-       -with-singularity /scratch/mri/singularityimages/scilus_1.6.0.sif \
-       -profile use_gpu,fully_reproducible \
-       -resume
-
-.. note::
-   The pipeline is configured to use the GPU profile and ensures full reproducibility.
+For users who need to understand the runtime environment, see the CRC documentation for `Jubail system details <https://crc-docs.abudhabi.nyu.edu/hpc/system/index.html>`_, `job submission and SLURM <https://crc-docs.abudhabi.nyu.edu/hpc/jobs/quick_start.html>`_, and `Singularity on HPC <https://crc-docs.abudhabi.nyu.edu/hpc/software/singularity_commands.html>`_.
 
 Troubleshooting
 ---------------
 
 - **Missing T1w or DWI**: The pipeline will fail immediately if these are not found in the BIDS structure.
 - **Registration Failures**: If the tracking results look wrong (e.g., streamlines exiting the brain), check the `report.html` for registration errors between T1w and DWI.
-- **Job Errors**: If the job fails, download the ``slurm-*.out`` and ``slurm-*.err`` logs from the ``tractoflow/logs`` directory (or `temp_files` if the transfer failed) and contact support.
+- **Job Errors**: If the job fails, download the available logs from the ``tractoflow/logs`` directory and contact support with the project, subject, session, and pipeline name.
 
 References
 ----------

--- a/docs/source/support/contributing.rst
+++ b/docs/source/support/contributing.rst
@@ -8,7 +8,7 @@ Reporting Issues
 
 If you find errors, have suggestions, or notice missing information, please raise an issue on our GitHub repository:
 
-- `GitHub Issues <https://github.com/XNAT-NYUAD/xnat-docs/issues>`_
+- `GitHub Issues <https://github.com/BioMedicalImaging-Core-NYUAD/xnat-docs/issues>`_
 
 When creating an issue, please include:
 - A clear description of the problem or suggestion

--- a/docs/source/support/faq.rst
+++ b/docs/source/support/faq.rst
@@ -49,22 +49,21 @@ Account and Access
 I forgot my password. How do I reset it?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Password reset procedures depend on your institution's authentication system:
+NYUAD XNAT uses Google OAuth for web sign-in. There is no separate XNAT password for normal browser access.
 
-**For NYU AD Users:**
-- Use NYU AD's NetID password reset system
-- Contact NYU AD IT support if needed
-- XNAT will automatically sync with updated credentials
+**For NYUAD users:**
+- Reset or recover access through the Google or NYU identity system associated with your approved account.
+- Contact NYUAD IT support if you cannot access that identity provider.
+- Contact XNAT administrators if your identity works but XNAT still does not let you sign in.
 
-**Self-Service Options:**
-- Look for "Forgot Password" link on the login page
-- Check your email for reset instructions
-- Contact your XNAT administrator if self-service isn't available
+**API and Desktop Client access:**
+- Use XNAT alias tokens rather than your Google password.
+- See :doc:`../working_with_xnat/access` for token creation instructions.
 
 **Security Best Practices:**
-- Use strong, unique passwords
-- Enable two-factor authentication if available
-- Never share login credentials
+- Never share login credentials or alias token secrets
+- Rotate alias tokens if you suspect they were exposed
+- Store tokens outside version-controlled scripts
 
 How do I change my account information?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -544,7 +543,7 @@ Error messages provide important clues for troubleshooting. Here's how to handle
 
 - Check :doc:`troubleshooting` for detailed error solutions
 - Review pipeline-specific documentation for processing errors
-- Consult the `official XNAT troubleshooting guide <https://wiki.xnat.org/documentation/getting-started-with-xnat/troubleshooting-xnat-login-and-session-issues>`_
+- Consult the `official XNAT troubleshooting guide <https://wiki.xnat.org/documentation/troubleshooting-xnat-login-and-session-issues>`_
 
 **When to Contact Support:**
 
@@ -724,7 +723,7 @@ XNAT provides a RESTful API for programmatic access to data and functionality:
 
 1. **Alias Tokens:** Generate in XNAT under your user profile → "Manage Alias Tokens"
 2. **Session Authentication:** Use JSESSIONID from web login
-3. **Basic Authentication:** Username/password (less secure, not recommended)
+3. **Basic Authentication:** Legacy username/password flows may not apply to NYUAD Google OAuth accounts. Use alias tokens unless administrators tell you otherwise.
 
 **Common API Operations:**
 

--- a/docs/source/support/troubleshooting.rst
+++ b/docs/source/support/troubleshooting.rst
@@ -3,12 +3,64 @@ Troubleshooting Guide
 
 This guide provides systematic approaches to resolving common issues with XNAT.
 
+Login and Access
+----------------
+
+**XNAT does not load**
+   Confirm that you are on the NYUAD network or connected to the NYUAD VPN. See :doc:`../working_with_xnat/access`.
+
+**Google sign-in works but project is missing**
+   Your account may not have access to that project. Request access using the instructions in :doc:`../working_with_xnat/access`.
+
+**A button or action is missing**
+   Your project role may not include that permission. Contact the project owner or XNAT administrators.
+
+Upload and Prearchive
+---------------------
+
+**Upload appears complete but data is not in the project**
+   Check the Prearchive. Uploaded sessions may be waiting for review before they appear in the Archive.
+
+**Session shows Conflict in Prearchive**
+   Review the session labels and Study Instance UIDs. For UID-specific conflicts, see :doc:`../working_with_xnat/uid_errors_archiving`.
+
+**Upload is slow or interrupted**
+   Use the XNAT Desktop Client for large uploads because it supports pause and resume. See :doc:`../working_with_xnat/uploading`.
+
+Pipeline Jobs
+-------------
+
+**Pipeline is not listed**
+   The pipeline may not be enabled for the project, or you may not have permission to run it. See :doc:`../working_with_xnat/enabling_pipelines`.
+
+**Pipeline fails immediately**
+   Check that the required input resource exists. For MRIQC, fMRIPrep, and TractoFlow, this usually means running dcm2bids first.
+
+**Pipeline finishes but output looks wrong**
+   Review the HTML report and logs before using the outputs for analysis. If you contact support, include the project, subject, session, pipeline name, and error logs.
+
+Downloads
+---------
+
+**Browser download fails**
+   Try the XNAT Desktop Client for large sessions or project-level downloads. See :doc:`../data_download/desktop_client`.
+
+**Desktop Client cannot connect**
+   Confirm the server URL, network access, and alias token/secret. See :doc:`../working_with_xnat/install_desktop_client`.
+
+Data Safety
+-----------
+
+**Data was deleted or appears missing**
+   Contact administrators immediately and include the project, subject, session, approximate time, and what changed. See :doc:`data_loss_recovery`.
+
 Getting Help
 ------------
 
-If you have tried the troubleshooting steps above and are still experiencing issues, please contact the XNAT administrators at admin.nyuad.xnat@nyu.edu.
+If you have tried the troubleshooting steps above and are still experiencing issues, contact the XNAT administrators at admin.nyuad.xnat@nyu.edu.
 
 Before contacting support, please:
+
 1. Try the solutions in this guide
 2. Check the :doc:`faq` section
 3. Gather error messages and logs

--- a/docs/source/understanding_data/overview.rst
+++ b/docs/source/understanding_data/overview.rst
@@ -39,7 +39,7 @@ You can also read more about this `here <https://wiki.xnat.org/documentation/und
 The ``Project`` level ``RESOURCE`` folder contains files that are shared across all subjects in the project. For example, we store the ``dcm2bids`` configuration file here, which is used to run the :doc:`../processing_pipelines/dcm2bids` pipeline.
 
 :doc:`../processing_pipelines/dcm2niix` pipeline is a scan level pipeline while :doc:`../processing_pipelines/dcm2bids` is a session level pipeline.
-:doc:`../processing_pipelines/dcm2bids` takes all the data under ``SCANS`` within a session and converts them to the the BIDS format (which is a standard way to structrure neuroimaging data). The output is stored in the session level ``RESOURCE`` folder called ``rawdata``.
+:doc:`../processing_pipelines/dcm2bids` takes all the data under ``SCANS`` within a session and converts them to the BIDS format (which is a standard way to structure neuroimaging data). The output is stored in the session level ``RESOURCE`` folder called ``rawdata``.
 This ``rawdata`` folder is then used as input for many other BIDS compliant pipelines such as the :doc:`../processing_pipelines/mriqc` and :doc:`../processing_pipelines/fmriprep`.
 
 Format Overview
@@ -83,4 +83,4 @@ Choosing Your Workflow
 Next Steps
 ----------
 
-- Learn about :doc:`bids` 
+- Learn about :doc:`bids`

--- a/docs/source/working_with_xnat/navigation.rst
+++ b/docs/source/working_with_xnat/navigation.rst
@@ -1,6 +1,44 @@
 XNAT Navigation Basics
 ======================
 
-This guide is coming soon.
+This guide introduces the main areas of the XNAT web interface and where common actions live.
 
-For now, you can access XNAT at https://xnat.abudhabi.nyu.edu and explore the interface. For help with specific navigation tasks, please see the :doc:`../support/faq` or :doc:`../support/contact` pages.
+Main Hierarchy
+--------------
+
+XNAT data is organized in a hierarchy:
+
+::
+
+   Project -> Subject -> Session -> Scan -> Resource
+
+- **Project**: A study, collaboration, or data collection.
+- **Subject**: A participant or research subject within a project.
+- **Session**: A visit or scan session for that subject.
+- **Scan**: An individual imaging series.
+- **Resource**: Files attached to a project, subject, session, or scan. Pipeline outputs are usually stored as resources.
+
+Finding Your Data
+-----------------
+
+1. Log into XNAT at https://xnat.abudhabi.nyu.edu.
+2. Open the project list from the home page or navigation menu.
+3. Select your project.
+4. Use the subject table to open the participant you need.
+5. Open the session to review scans, resources, and available actions.
+
+Common Actions
+--------------
+
+- **Upload data**: Use the project or upload menu. See :doc:`uploading`.
+- **Review pending uploads**: Use **Upload** > **Go to prearchive**. See :doc:`prearchive`.
+- **Download data**: Use browser download options or the Desktop Client. See :doc:`../data_download/browser`.
+- **Run a pipeline**: Open the session or project and use the available actions menu. See :doc:`running_pipelines`.
+- **Manage project settings**: Project owners can adjust selected project settings. See :doc:`project_management`.
+
+Tips
+----
+
+- If a button or menu item is missing, you may not have the required project role.
+- If a session is not where you expect it to be, check the Prearchive before assuming the upload failed.
+- Use consistent subject and session labels. This avoids accidental merges and makes pipeline outputs easier to interpret.

--- a/docs/source/working_with_xnat/prearchive.rst
+++ b/docs/source/working_with_xnat/prearchive.rst
@@ -96,5 +96,5 @@ See Also
 
 **Official XNAT Documentation**
 
-- `XNAT Wiki: Prearchive <https://wiki.xnat.org/display/XNAT18/Prearchive>`_ - Official documentation on the Prearchive system
-- `XNAT Wiki: Archiving Data <https://wiki.xnat.org/display/XNAT18/Archiving+Data>`_ - Information about the archiving process
+- `XNAT Wiki: Prearchive search <https://wiki.xnat.org/search.html?l=en&max=10&ol=&q=Prearchive&s=documentation&start=0>`_ - Official documentation search results for the Prearchive system
+- `XNAT Wiki: Archiving Data search <https://wiki.xnat.org/search.html?l=en&max=10&ol=&q=Archiving+Data&s=documentation&start=0>`_ - Official documentation search results for the archiving process

--- a/docs/source/working_with_xnat/project_management.rst
+++ b/docs/source/working_with_xnat/project_management.rst
@@ -1,6 +1,58 @@
 Project Management
 ==================
 
-This guide is coming soon.
+This guide summarizes common project-level tasks for project owners and coordinators.
 
-For project management assistance, please contact the XNAT administrators at admin.nyuad.xnat@nyu.edu.
+Project Roles
+-------------
+
+XNAT access is controlled at the project level. Common roles include:
+
+- **Owner**: Can manage project settings, users, and data.
+- **Member**: Can usually view, upload, download, and run enabled workflows.
+- **Read-only access**: Can view and download data when permitted.
+
+Exact permissions can vary by project configuration. If a user cannot see an expected action, first confirm their project role.
+
+Adding or Updating Access
+-------------------------
+
+To request project access changes, email admin.nyuad.xnat@nyu.edu with:
+
+- Project ID or project name
+- User name and email address
+- Requested role
+- Brief reason for the access request
+
+Use the least privileged role that supports the user's work.
+
+Project Setup Checklist
+-----------------------
+
+Before collecting or uploading data, project owners should confirm:
+
+1. Project name and ID are correct.
+2. Subject and session label conventions are documented.
+3. Upload destination is understood: Prearchive or Archive.
+4. Required pipelines are enabled. See :doc:`enabling_pipelines`.
+5. Project members know how to request support.
+6. Data anonymization requirements are clear to the research team.
+
+Naming Conventions
+------------------
+
+Consistent labels make uploads, transfers, and analysis easier. A simple convention such as ``sub-0001`` and ``ses-01`` works well for many projects.
+
+Avoid spaces, special characters, and labels that could identify participants. Use only project-approved identifiers.
+
+When to Contact Administrators
+------------------------------
+
+Contact admin.nyuad.xnat@nyu.edu for:
+
+- New project setup
+- Large access changes
+- Pipeline enablement or custom pipeline requests
+- Bulk transfer planning
+- Unexpected merge, deletion, or archiving issues
+- Questions about public documentation or user guidance

--- a/docs/source/working_with_xnat/running_pipelines.rst
+++ b/docs/source/working_with_xnat/running_pipelines.rst
@@ -1,112 +1,84 @@
 Running Pipelines on XNAT
 =========================
 
-This page provides general instructions for running any processing pipeline on XNAT. Individual pipeline pages reference this guide for the basic workflow.
+This page explains the common workflow for launching processing pipelines from the XNAT web interface. Individual pipeline pages describe the inputs and outputs for each tool.
 
-General Pipeline Interface
---------------------------
+Before You Start
+----------------
 
-All pipelines on XNAT follow the same basic interface through the web UI:
+Before launching a pipeline, check the following:
 
-1. **Navigate to your project**
-2. **Select the subject and session**
-3. **Access the pipeline launcher**
-4. **Configure pipeline parameters**
-5. **Submit the job**
-6. **Monitor progress and results**
+- You have access to the project and session you want to process.
+- The pipeline is enabled for your project. See :doc:`enabling_pipelines`.
+- The required input data is present. For BIDS-based pipelines, run :doc:`../processing_pipelines/dcm2bids` first.
+- You understand where the output will appear, usually in the session or project **Resources** area.
 
-Step-by-Step Instructions
--------------------------
+Session-Level Pipelines
+-----------------------
 
-**1. Navigate to Your Data**
+Most conversion, quality-control, and preprocessing pipelines are launched from an imaging session.
 
-- Log into XNAT (https://xnat.abudhabi.nyu.edu)
-- Select your project from the project list
-- Navigate to the subject and session you want to process
+1. Log into XNAT at https://xnat.abudhabi.nyu.edu.
+2. Open your project.
+3. Open the subject and session you want to process.
+4. Use the session actions menu to choose the available pipeline launcher. Depending on the pipeline, this may appear as **Run Pipeline**, **Run Preprocessing Pipeline**, or **Run Containers**.
+5. Select the pipeline.
+6. Review the parameters. Leave optional fields unchanged unless the pipeline page tells you to change them.
+7. Submit the job.
+8. Monitor the job status and review logs if the job fails.
 
-**2. Launch Pipeline Interface**
+Project-Level Pipelines
+-----------------------
 
-[PLACEHOLDER - Screenshot of pipeline button location]
+Some workflows run across multiple sessions or subjects from the project page. Examples include group-level quality-control reports or project-wide batch launches.
 
-- On the session page, look for the "Run Pipeline" or "Actions" button
-- Click to open the pipeline selection interface
+1. Open the project page.
+2. Use the project actions menu to find the batch or container launcher.
+3. Select the pipeline and the subjects or sessions to include.
+4. Submit the job and monitor progress from the project or processing view.
 
-**3. Select Pipeline**
+For multi-subject launches, see :doc:`parallel_processing`.
 
-[PLACEHOLDER - Screenshot of pipeline selection dropdown]
+Choosing Parameters
+-------------------
 
-- Choose the desired pipeline from the dropdown menu
-- Available pipelines depend on your project configuration
+Pipeline forms vary, but these fields are common:
 
-**4. Configure Parameters**
+- **Subject or session label**: Usually auto-filled from the XNAT session. Change only when the pipeline documentation explicitly asks you to.
+- **Input resource**: The folder or resource the pipeline reads from, such as ``rawdata`` for BIDS inputs.
+- **Output resource**: The folder where results will be stored, such as ``mriqc``, ``fmriprep``, or ``tractoflow``.
+- **Optional flags**: Advanced command options. Use these carefully; invalid flags can cause jobs to fail.
 
-[PLACEHOLDER - Screenshot of parameter configuration interface]
+Monitoring Results
+------------------
 
-- **Input Selection:** Choose which scans to process
-- **Output Destination:** Specify where results should be stored
-- **Pipeline Parameters:** Set pipeline-specific options
-- **Resource Allocation:** Configure computing resources (if applicable)
+After submission:
 
-**5. Submit Job**
-
-[PLACEHOLDER - Screenshot of job submission button]
-
-- Review your configuration
-- Click "Submit" or "Run" to start the pipeline
-- Note the job ID for tracking
-
-**6. Monitor Progress**
-
-[PLACEHOLDER - Screenshot of job monitoring interface]
-
-- Check job status in the "Processing" or "Jobs" section
-- Monitor logs for progress and any errors
-- Receive notifications when job completes
-
-Common Parameters
------------------
-
-**Input Selection:**
-- **Scan Selection:** Choose specific scans to process
-- **Session Level:** Process entire session
-- **Quality Control:** Include/exclude based on QC status
-
-**Output Configuration:**
-- **Output Location:** Where to store results
-- **Naming Convention:** How to name output files
-- **Sharing Settings:** Who can access results
-
-**Processing Options:**
-- **Resource Allocation:** CPU, memory, time limits
-- **Notification Settings:** Email alerts for completion
-- **Debug Mode:** Enable detailed logging
+- Check the job status in XNAT.
+- Wait for the pipeline to finish before launching dependent pipelines.
+- Open the output resource and review reports or logs.
+- For quality-control and preprocessing pipelines, inspect HTML reports before using the derivatives for analysis.
 
 Troubleshooting
 ---------------
 
-**Common Issues:**
-- **Permission Errors:** Check project access rights
-- **Input Validation:** Ensure required scans are present
-- **Resource Limits:** Job may need more time or memory
-- **Network Issues:** Check XNAT connectivity
+**Pipeline is not listed**
+   The pipeline may not be enabled for the project, or you may not have permission to run it. See :doc:`enabling_pipelines`.
 
-**Getting Help:**
-- Check pipeline logs for specific error messages
-- Review pipeline documentation for parameter requirements
-- Contact support if issues persist
+**Pipeline fails quickly**
+   Check whether the required input resource exists and whether the session labels match the expected format.
 
-**Data Loss Concerns:**
-- If you accidentally delete pipeline outputs or data, see :doc:`../support/data_loss_recovery` for recovery options
-- Contact XNAT administrators immediately if critical data is lost
+**Pipeline runs but output is missing**
+   Check the logs in the output resource. If the transfer back to XNAT failed, include the workflow ID and session label when contacting support.
+
+**Pipeline takes longer than expected**
+   Some pipelines, especially fMRIPrep and TractoFlow, can take many hours. If a job appears stuck or repeatedly times out, contact support with the project, subject, session, pipeline name, and any available logs.
+
+For more help, see :doc:`../support/troubleshooting`.
 
 Next Steps
 ----------
 
-After completing this general overview:
-
-- Explore specific pipeline documentation:
-  - :doc:`../processing_pipelines/dcm2bids` for DICOM conversion
-  - :doc:`../processing_pipelines/fmriprep` for fMRI preprocessing
-  - :doc:`../processing_pipelines/tractoflow` for tractography
-- Learn about :doc:`../data_download/browser` for accessing results
-- See :doc:`../support/troubleshooting` for common issues
+- Explore :doc:`../processing_pipelines/overview` for available pipelines.
+- Read the page for the specific pipeline you want to run.
+- Use :doc:`../data_download/browser` or :doc:`../data_download/desktop_client` to access results.

--- a/docs/source/working_with_xnat/uid_errors_archiving.rst
+++ b/docs/source/working_with_xnat/uid_errors_archiving.rst
@@ -261,8 +261,8 @@ See Also
 
 **Official XNAT Documentation**
 
-- `XNAT Wiki: Archiving Data <https://wiki.xnat.org/display/XNAT18/Archiving+Data>`_ - Official documentation on the archiving process
-- `XNAT Wiki: Prearchive <https://wiki.xnat.org/display/XNAT18/Prearchive>`_ - Information about the Prearchive system
+- `XNAT Wiki: Archiving Data search <https://wiki.xnat.org/search.html?l=en&max=10&ol=&q=Archiving+Data&s=documentation&start=0>`_ - Official documentation search results for the archiving process
+- `XNAT Wiki: Prearchive search <https://wiki.xnat.org/search.html?l=en&max=10&ol=&q=Prearchive&s=documentation&start=0>`_ - Official documentation search results for the Prearchive system
 
 **Support**
 

--- a/docs/source/working_with_xnat/uploading.rst
+++ b/docs/source/working_with_xnat/uploading.rst
@@ -15,7 +15,7 @@ XNAT provides multiple ways to upload research data, each suited for different u
    *   **Prearchive**: Staging area. Data can be edited or deleted.
    *   **Archive**: Permanent storage. Data is indexed and protected.
    
-   For more details about the Prearchive, see :doc:`prearchive`. For official XNAT documentation, refer to the `Official XNAT Documentation on Data Archiving <https://wiki.xnat.org/display/XNAT18/Archiving+Data>`_.
+   For more details about the Prearchive, see :doc:`prearchive`. For official XNAT documentation, refer to the `XNAT Wiki Archiving Data search <https://wiki.xnat.org/search.html?l=en&max=10&ol=&q=Archiving+Data&s=documentation&start=0>`_.
 
 Important Considerations
 ------------------------
@@ -58,11 +58,7 @@ This method is the standard way for MRI scanners and automated scripts (like `st
 
 **Connection Details**
 
-Configure your scanner or sender script with the following parameters:
-
-*   **Remote AE Title**: ``xnatad``
-*   **Remote IP**: ``10.230.12.52``
-*   **Remote Port**: ``8104``
+The NYUAD DICOM receiver is available only from the approved NYUAD network. Receiver host, port, and AE title values may change as infrastructure is updated, so approved users should contact the XNAT administrators for the current connection details before configuring a scanner or sender script.
 
 **How it works**
 
@@ -93,7 +89,7 @@ If the Study Description field contains no routing information or conflicting in
 The **XNAT Desktop Client** is a standalone application that provides a robust way to upload large batches of data or complex folder structures. It is recommended for users who prefer a graphical interface with resumable uploads.
 
 **Installation**
-Ensure you have the XNAT Desktop Client installed. (See :doc:`install_desktop_client` if available, or check the `Official XNAT Desktop Client Wiki <https://wiki.xnat.org/xnat-tools/xnat-desktop-client>`_).
+Ensure you have the XNAT Desktop Client installed. See :doc:`install_desktop_client` or the `Official XNAT Desktop Client Wiki <https://wiki.xnat.org/xnat-tools/xnat-desktop-client-dxm>`_.
 
 **Step-by-Step Upload Guide**
 
@@ -156,7 +152,7 @@ For more details on bulk upload workflows, see the `official XNAT documentation 
     
     As long as the application is running and you have an active network connection, uploads will proceed in the background.
 
-For more information on managing transfers, see the `official XNAT documentation on managing data transfers <https://wiki.xnat.org/xnat-tools/managing-data-transfers>`_.
+For more information on the Desktop Client, see the `official XNAT Desktop Client documentation <https://wiki.xnat.org/xnat-tools/xnat-desktop-client-dxm>`_.
 
 **Project Settings**
 
@@ -253,7 +249,7 @@ Troubleshooting
 
 **Common Issues**
 
-*   **Connection Refused (DICOM Receiver)**: Ensure you are on the correct network (VPN/Intranet) to access ``10.230.12.52``. For routing issues, verify the DICOM Study Description field contains ``xnat://project_id/subject_label/session_label``. Missing or incorrect routing strings require manual routing from the Prearchive.
+*   **Connection Refused (DICOM Receiver)**: Ensure you are on the approved NYUAD network or VPN and that you are using the current receiver details from the XNAT administrators. For routing issues, verify the DICOM Study Description field contains ``xnat://project_id/subject_label/session_label``. Missing or incorrect routing strings require manual routing from the Prearchive.
 
 *   **Permission Errors**: Ensure you have "Member" or "Owner" access to the destination project. If subject creation is restricted, register subjects in the project before uploading.
 
@@ -285,6 +281,6 @@ See Also
 **Official XNAT Documentation**
 
 *   `XNAT Wiki: Uploading Image Sessions <https://wiki.xnat.org/xnat-tools/uploading-image-sessions>`_ - Comprehensive guide to uploading image sessions
-*   `XNAT Desktop Client Documentation <https://wiki.xnat.org/xnat-tools/xnat-desktop-client>`_ - Complete Desktop Client reference
+*   `XNAT Desktop Client Documentation <https://wiki.xnat.org/xnat-tools/xnat-desktop-client-dxm>`_ - Complete Desktop Client reference
 *   `Setting Project Defaults for Desktop Client Behavior <https://wiki.xnat.org/xnat-tools/setting-project-defaults-for-desktop-client-behavi>`_ - Project configuration options
-*   `Managing Data Transfers <https://wiki.xnat.org/xnat-tools/managing-data-transfers>`_ - Transfer management guide
+*   `XNAT Desktop Client Application Settings <https://wiki.xnat.org/xnat-tools/application-settings>`_ - Desktop Client configuration reference


### PR DESCRIPTION
## Summary

This PR updates the public NYUAD XNAT user documentation with a broad cleanup pass and a new extensive Python/XNAT API guide.

## Changes

- Rewrites the Python download page as an `XNAT API with Python` guide covering setup, alias tokens, secrets management, common download patterns, Jubail workflows, AI-assisted script generation, troubleshooting, and admin support.
- Fills out user-facing pages that were previously sparse or placeholder-like, including navigation, project management, running pipelines, and troubleshooting.
- Softens internal implementation details in pipeline docs while linking users to official Jubail/SLURM/Singularity documentation where relevant.
- Updates stale links and public-facing language around authentication, downloads, prearchive behavior, UID errors, and contribution guidance.
- Pins docs dependencies and updates the README prerequisite to Python 3.10+.

## Validation

- `git diff --check`
- `../.venv/bin/sphinx-build -b html -W --keep-going source /private/tmp/xnat-docs-recommendations-html`
- `../.venv/bin/sphinx-build -b linkcheck --keep-going source /private/tmp/xnat-docs-recommendations-linkcheck`
- Local preview verified at `http://127.0.0.1:8031/data_download/python_scripts.html`